### PR TITLE
pkgs.contrail.vrouterNetns: use system sudo

### DIFF
--- a/pkgs/contrail.nix
+++ b/pkgs/contrail.nix
@@ -251,7 +251,11 @@ rec {
       docker netaddr vrouterApi eventlet vnc_api cfgm_common
     ];
     makeWrapperArgs = [
-      "--prefix PATH : ${pkgs.iptables}/bin:${pkgs.procps}/bin:${pkgs.nettools}/bin:${pkgs.iproute}/bin:${pkgs.sudo}/bin"
+      # FIXME: can't use sudo from nix:
+      # sudo: error in /etc/sudo.conf, line 0 while loading plugin "sudoers_policy"
+      # sudo: /nix/store/sq341cfimmyq5mn6fyb25z8nndqsdrp6-sudo-1.8.22/libexec/sudo/sudoers.so must be owned by uid 0
+      # sudo: fatal error, unable to load plugins'
+      "--prefix PATH : ${pkgs.iptables}/bin:${pkgs.procps}/bin:${pkgs.nettools}/bin:${pkgs.iproute}/bin"
     ];
   };
 


### PR DESCRIPTION
vrouterNetns is running some `ip netns` commands with sudo but it fails
with the sudo package from nix because of permissions and missing
plugins.

As a workaround we can use the sudo installed on the system.