### PR TITLE
contrail.log4cplus: init at 1.2.0

### DIFF
--- a/contrail-overlay.nix
+++ b/contrail-overlay.nix
@@ -27,10 +27,8 @@ let
       scons gcc5 pkgconfig autoconf automake libtool flex_2_5_35 bison
       # Global build deps
       libkrb5 openssl libxml2 perl curl
-      # This overriding should be avoided by patching log4cplus to
-      # support older compilers.
+      lself.log4cplus
       (tbb.override{stdenv = stdenv_gcc5;})
-      (log4cplus.override{stdenv = stdenv_gcc5;})
       (boost155.override{
         buildPackages.stdenv.cc = gcc5;
         stdenv = stdenv_gcc5;
@@ -107,6 +105,7 @@ let
     # deps
     cassandraCppDriver = callPackage ./pkgs/cassandra-cpp-driver.nix { stdenv = stdenv_gcc6; };
     libgrok = callPackage ./pkgs/libgrok.nix { };
+    log4cplus = callPackage ./pkgs/log4cplus.nix { stdenv = stdenv_gcc5; };
 
     # vrouter
     vrouterAgent = callPackage ./pkgs/vrouter-agent.nix { stdenv = stdenv_gcc5; };

--- a/pkgs/log4cplus.nix
+++ b/pkgs/log4cplus.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchurl }:
+
+let
+  name = "log4cplus-1.2.0";
+in
+stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchurl {
+    url = "mirror://sourceforge/log4cplus/${name}.tar.bz2";
+    sha256 = "1fb3g9l12sps3mv4xjiql2kcvj439mww3skz735y7113cnlcf338";
+  };
+
+  meta = {
+    homepage = http://log4cplus.sourceforge.net/;
+    description = "A port the log4j library from Java to C++";
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
nixpkgs-unstable bumped log4cplus to version 2.x.

contrail doesn't compile with it:
http://84.39.63.212/log/9rcv9yvmn7j4zpi6kk6ya48ciwzqwpqb-contrail-collector-3.2.drv