### PR TITLE
Fix gremlin-server

### DIFF
--- a/tools/gremlin-server/default.nix
+++ b/tools/gremlin-server/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "gremlin-server-${version}";
   version = "3.3.2";
   src = fetchzip {
-    url = "http://www-eu.apache.org/dist/tinkerpop/${version}/apache-tinkerpop-gremlin-server-${version}-bin.zip";
+    url = "http://archive.apache.org/dist/tinkerpop/${version}/apache-tinkerpop-gremlin-server-${version}-bin.zip";
     sha256 = "0plx7m51av0kjr6x4rbsmsz5p03j980gh56czj3rfin10565v5kr";
   };
   buildInputs = [ makeWrapper openjdk ];


### PR DESCRIPTION
The source URL for `gremlin-server` was not valid anymore.